### PR TITLE
Add text on undocumented errors to OAS definition

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -48,6 +48,11 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    ### Additional CAMARA error responses
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+
     # Multi-SIM scenario handling
 
     In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the enhanced QoS profile should apply from that phone number. If the phone number is used as the device identifier when creating a QoS booking in a multi-SIM scenario, the API may respond with an error, apply the enhanced QoS profile to all devices in the multi-SIM group, or apply the enhanced QoS profile to a single device in the multi-SIM group which may not be the intended device.


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Adds mandatory text on undocumented errors to the OAS info.description section as defined [here](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#33-error-responses---mandatory-template-for-infodescription-in-camara-api-specs)

#### Which issue(s) this PR fixes:
Fixes #21 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note

```

#### Additional documentation 
None
