### PR TITLE
Add support for multiple device qos-booking

### DIFF
--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -1,0 +1,1616 @@
+openapi: 3.0.3
+info:
+  title: Aggregate QoS Booking and Device Assignment
+  description: |
+    This API enables API consumers to request, in advance, certain network performance to be provided by Telco networks, without having in-depth knowledge of the underlying network complexities (e.g. the 4G/5G system in case of a mobile network) for a number of devices, at a given location, for a period of time.
+
+    The API enables API consumers to book a specific QoS profile for one or more devices with conditions such as the start time, duration and location. Once the booking is confirmed the enduser can assign devices to the booking.
+    The network operator will provision and activate those devices with the required and agreed network quality at the given time and conditions
+
+    # Relevant terms and definitions
+
+    * **QoS profiles**:
+    Latency, throughput or priority requirements of the application mapped to relevant QoS profile values. The set of QoS Profiles that a network operator is offering may be retrieved via the `qos-profiles` API (cf. https://github.com/camaraproject/QualityOnDemand/) or will be agreed during the onboarding with the API service provider.
+
+    * **Identifier for the device**:
+    At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the network operator for the device, at the request time. After the booking request is accepted, the device may get different IP addresses, but the booking will still apply to the device that was identified during the request process. Note: Network Access Identifier is defined for future use and will not be supported with v0.1 of the API.
+
+    * **Notification URL and token**:
+    API consumers may provide a callback URL (`sink`) on which notifications about all status change events (e.g. duration expiration) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. In the current version,`sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if provided.
+
+    # Resources and Operations overview
+    The API defines six major operations in two groups:
+    
+    Booking:
+
+    - An operation to setup a new QoS Booking for one or more devices.
+    - An operation to get the information about an existing QoS Booking, identified by its `BookingId`.
+    - An operation to terminate an existing QoS Booking, identified by its `BookingId`.
+
+    Device Assignment:
+
+     - An operation to assign one or more devices to the existing booking identified by its 'BookingId'
+     - An operation to release one or more devices from the booking identified by its 'BookingId'
+     - An operation to get all the associated QoS Booking for a given device.
+
+    # Authorization and authentication
+
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+
+    In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+
+    # Identifying the device from the access token
+
+    This API requires the API consumer to identify a device as the subject of the API as follows:
+    - When the API is invoked using a two-legged access token, the subject will be identified from the optional `device` object, which therefore MUST be provided.
+
+    - When a three-legged access token is used however, this optional identifier MUST NOT be provided, as the subject will be uniquely identified from the access token.
+
+    This approach simplifies API usage for API consumers using a three-legged access token to invoke the API by relying on the information that is associated with the access token and was identified during the authentication process.
+
+    ## Error handling:
+    - If the subject cannot be identified from the access token and the optional `device` object is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
+
+    - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
+
+    # Multi-SIM scenario handling
+
+    In multi-SIM scenarios where more than one mobile device is associated with a phone number (e.g. a smartphone with an associated smartwatch), it might not be possible to uniquely identify the device to which the enhanced QoS profile should apply from that phone number. If the phone number is used as the device identifier when creating a QoS booking in a multi-SIM scenario, the API may respond with an error, apply the enhanced QoS profile to all devices in the multi-SIM group, or apply the enhanced QoS profile to a single device in the multi-SIM group which may not be the intended device.
+
+    Possible solutions in such a scenario include:
+    - Using the authorisation code flow to obtain an access token, which will automatically identify the intended device
+    - Identifying the intended device from a unique identifier for that device, such as its source IP address and port
+    - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
+
+    # Further info and support
+
+    (FAQs will be added in a later version of the documentation)
+
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: wip
+  x-camara-commonalities: 0.5
+
+externalDocs:
+  description: Project documentation at CAMARA
+  url: https://github.com/camaraproject/QoSBooking
+
+servers:
+  - url: "{apiRoot}/qos-booking-and-assignment/vwip"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+tags:
+  - name: Advance QoS Booking
+    description: Book and manage QoS for multiple devices in advance
+  - name: Device QoS Assignment
+    description: Manage the assignment of devices of QoS
+
+paths:
+  /book-qos:
+    post:
+      tags:
+        - Advance QoS Booking
+      summary: Reserve QoS in advance for one or more devices. Devices can be assigned later to this booking
+      description: |
+        Triggers a new booking in advance and assign this reserved booking profile to one or more devices when the devices are ready.
+
+        - If the booking is completed synchronously, the response will be 201 with `status` = `SCHEDULED`.
+        - If the booking request is accepted but not yet completed, the response will be 201 with `status` = `REQUESTED`. 
+        - If the operator determines synchronously that the booking request cannot be fulfilled, the response will be 201 with `status` = `UNAVAILABLE`.
+        - If the request includes a notification callback, the client will receive a `status-changed` event with the outcome of the process. The event will be sent also for synchronous operations.
+        - The devices can be assigned anytime from the time booking is SCHEDULED and before the scheduled duration ends.
+        - StatusInfo contains additional information under certain conditions. 
+
+      operationId: createBooking
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Input Parameters to create a new booking
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BookingInput"
+        required: true
+      callbacks:
+        notifications:
+          "{$request.body#/sink}":
+            post:
+              summary: Booking notifications callback
+              description: |
+                Important: this endpoint is to be implemented by the API consumer.
+                The API provider will call this endpoint whenever any QoS Booking change related event occurs.
+                Currently only `BOOKING_STATUS_CHANGED` event is defined.
+              operationId: postBookingNotification
+              parameters:
+                - $ref: "#/components/parameters/x-correlator"
+              requestBody:
+                required: true
+                content:
+                  application/cloudevents+json:
+                    schema:
+                      $ref: "#/components/schemas/CloudEvent"
+                    examples:
+                      BOOKING_STATUS_CHANGED_EXAMPLE:
+                        $ref: "#/components/examples/BOOKING_STATUS_CHANGED_EXAMPLE"
+              responses:
+                "204":
+                  description: Successful notification
+                  headers:
+                    x-correlator:
+                      $ref: "#/components/headers/x-correlator"
+                "400":
+                  $ref: "#/components/responses/Generic400"
+                "401":
+                  $ref: "#/components/responses/Generic401"
+                "403":
+                  $ref: "#/components/responses/Generic403"
+                "410":
+                  $ref: "#/components/responses/Generic410"
+              security:
+                - {}
+                - notificationsBearerAuth: []
+      responses:
+        "201":
+          description: Booking created
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BookingOutput"
+        "400":
+          $ref: "#/components/responses/CreateBooking400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "409":
+          $ref: "#/components/responses/BookingConflict409"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:book-qos:create"
+
+  /existing-qos-booking/{bookingId}:
+    get:
+      tags:
+        - Advance QoS Booking
+      summary: Get the Booking information for an existing QoS Booking.
+      description: |
+        This endpoint gets booking information for the given bookingId.  
+        - A booking may be UNAVAILABLE (INVALID, EXPIRED, or CANCELLED). StatusInfo contains additional information.
+        - Based on the status of the booking, an appropriate error message will be returned.
+        - If a booking is AVAILABLE (booking is ACTIVE) then this endpoint will return the booking information along with device information for the devices, if any, assigned to the booking.
+        - StatusInfo contains additional information under certain conditions. 
+
+      operationId: getBookingById
+      parameters:
+        - $ref: "#/components/parameters/BookingId"
+        - $ref: "#/components/parameters/x-correlator"
+      responses:
+        "200":
+          description: Returns information about certain booking
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAssignmentOutput"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:existing-qos-booking:read"
+
+    delete:
+      tags:
+        - Advance QoS Booking
+      summary: Cancel an existing QoS Booking
+      description: |
+        Cancel an existing booking and release resources related to that booking.
+        - The QoS Booking must have been created by the same API client given in the access token.
+        - SUCCESS and FAILURE condition of deleting a booking is based on the implementation of the operator. 
+        - Operator SHOULD properly document their 'delete' behavior.  Following are some guidelines:
+     
+        - If booking is made, and no devices are assigned -- SUCCESS - Return message will contain only booking info.
+        - If booking is made, and devices are assigned, but session is not active - SUCCESS. Return message will contain information related to booking as well as assigned devices
+        - If booking is made, and devices are not assigned, but session is active - SUCCESS - Return message will contain only booking info
+        - If booking is made, and devices are assigned, and session is active - SUCCESS / FAILURE is determined by the operator. Operator may terminate the session, release the devices and release the booking.
+
+      operationId: deleteBooking
+      parameters:
+        - $ref: "#/components/parameters/BookingId"
+        - $ref: "#/components/parameters/x-correlator"
+      responses:
+        "200":
+          description: Booking deleted. 'status' in the response will be 'CANCELLED'
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAssignmentOutput"
+        "202":
+          description: Deletion request accepted to be processed. It applies for an async deletion process. `status` in the response will be `SCHEDULED` 
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAssignmentOutput"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:existing-qos-booking:delete"
+
+  /assign-devices-to-booking:
+    post:
+      tags:
+        - Device QoS Assignment
+      summary: Assign one or more devices to the existing QoS Booking
+      description: |
+        This end-point allows the enduser to assign one or more devices to the exisitng QoS Booking. 
+        - status = 'AVAILABLE' if the assignment is successful and the network is available for the said devices to connect and use them at the requested time 
+        - status = 'UNAVAILABLE'  if the assignment is unsuccessful and the StatusInfo will have more information.
+        - This is an asynchronus call,  and status = REQUESTED if the network is still working on your request. A callback will come with appropriate status. 
+        - StatusInfo contains additional information under certain conditions. 
+        
+      operationId: assignDevices
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to create a new booking
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceAssignmentInput"
+        required: true
+      callbacks:
+        notifications:
+          "{$request.body#/sink}":
+            post:
+              summary: Booking notifications callback
+              description: |
+                Important: this endpoint is to be implemented by the API consumer.
+                The API provider will call this endpoint whenever any QoS Assignment change related event occurs.
+              operationId: postAssignmentNotification
+              parameters:
+                - $ref: "#/components/parameters/x-correlator"
+              requestBody:
+                required: true
+                content:
+                  application/cloudevents+json:
+                    schema:
+                      $ref: "#/components/schemas/CloudEvent"
+              responses:
+                "204":
+                  description: Successful notification
+                  headers:
+                    x-correlator:
+                      $ref: "#/components/headers/x-correlator"
+                "400":
+                  $ref: "#/components/responses/Generic400"
+                "401":
+                  $ref: "#/components/responses/Generic401"
+                "403":
+                  $ref: "#/components/responses/Generic403"
+                "410":
+                  $ref: "#/components/responses/Generic410"
+              security:
+                - {}
+                - notificationsBearerAuth: []
+      responses:
+        "201":
+          description: At least one device is assigned to the booking. The developer can call this endpoint mulitple times with appropriate information
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAssignmentOutput"
+        "400":
+          $ref: "#/components/responses/CreateBooking400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "409":
+          $ref: "#/components/responses/BookingConflict409"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:assign-devices-to-booking:create"
+
+  /release-devices-from-booking:
+    post:
+      tags:
+        - Device QoS Assignment
+      summary: Release one or more devices from the given QoS Booking
+      description: Release one or more already assigned devices. This is a synchronous call. 
+      operationId: deleteQoS
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to release devices
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceAssignmentInput"
+        required: true
+      responses:
+        "201":
+          description: Release of devices successful
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceAssignmentOutput"
+        "400":
+          $ref: "#/components/responses/CreateBooking400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "409":
+          $ref: "#/components/responses/BookingConflict409"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:assign-devices-to-booking:delete"
+
+  /retrieve-bookings-of-a-device:
+    post:
+      tags:
+        - Device QoS Assignment
+      summary: Retrieves all the bookings that corresponds to a device
+      description: |
+        Querying for QoS Booking resource information details for a device.
+
+        **NOTES:**
+        - The access token may be either 2-legged or 3-legged.
+          - If a 3-legged access token is used, the subject associated with the QoS Booking must also be associated with the access token.  In this case the optional `device` parameter MUST NOT be provided in the request.
+          - If a 2-legged access token is used, the device parameter must be provided and identify a device.
+        - The QoS Booking must have been created by the same API client given in the access token.
+        - If no QoS booking is found for the requested device, an empty array is returned.
+        - This call uses the POST method instead of GET to comply with the CAMARA Commonalities guidelines for sending sensitive or complex data in API calls. Since the device field may contain personally identifiable information, it should not be sent via GET.
+
+      operationId: retrieveBookingByDevice
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to retrieve a booking by device
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RetrieveBookingByDevice"
+        required: true
+      responses:
+        "200":
+          description: Returns the QoS booking information for a given device. A device may have multiple bookings (for several times and locations), thus the response is an array. An empty array is returned if no sessions are found.
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RetrieveBookingsOutput"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking-and-assignment:retrieve-bookings-of-a-device:read"
+
+components:
+  securitySchemes:
+    openId:
+      description: OpenID Connect authentication
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+    notificationsBearerAuth:
+      description: Bearer authentication for notifications
+      type: http
+      scheme: bearer
+      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+
+  parameters:
+    BookingId:
+      name: bookingId
+      in: path
+      description: Booking ID that was obtained from the createBooking operation
+      required: true
+      schema:
+        $ref: "#/components/schemas/BookingId"
+
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        type: string
+        pattern: ^[a-zA-Z0-9-]{0,55}$
+        example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        type: string
+        pattern: ^[a-zA-Z0-9-]{0,55}$
+
+  schemas:
+    BookingId:
+      description: Booking Identifier in UUID format
+      type: string
+      format: uuid
+    
+    BookingProfile: 
+      description: |
+        Booking Profile contains all the key properties of any booking.  This includes:
+        - `qosProfile`  - This is the operator defined profile for the quality of service. This is generally advertised by the oeprator via their portal and/or documentation
+        - `startTime`   - Date and Time the booking is needed
+        - `duration`   - The number of seconds the booking is needed
+        - `serviceArea` - It is the location in which the service is needed
+      allOf:
+        - type: object
+          properties:              
+            qosProfile:
+              $ref: "#/components/schemas/QosProfileName"
+            startTime:
+              $ref: "#/components/schemas/Time"
+            duration:
+              $ref: "#/components/schemas/Duration"
+            serviceArea:
+              $ref: "#/components/schemas/Area"            
+          required:
+            - qosProfile
+            - startTime
+            - duration
+            - serviceArea
+
+    BookingInput: 
+      description: |
+        Basic input that are required for to book QoS in advance.  
+        - 'numDevices' is optional and it is defaulted to 1.  
+        - 'numDevices' represents the maximum number of devices the enduser wants the operator to reserve
+      allOf:
+        - type: object
+          properties:
+            numDevices:
+              $ref: "#/components/schemas/DeviceCount"                   
+            bookingProfile:
+              $ref: "#/components/schemas/BookingProfile"
+            sink:
+              type: string
+              format: uri
+              description: The address to which events shall be delivered, using the HTTP protocol.
+              example: "https://endpoint.example.com/sink"
+            sinkCredential:
+              $ref: "#/components/schemas/SinkCredential"              
+          required:
+            - bookingProfile
+    
+    BookingOutput: 
+      description: |
+        - If the booking endpoint returns synchronously, BookingOut will be part of the return message body. For async success a follow-up 'get' call will retrun the details of the actual booking.
+        - It returns original number of devices that are requested as well as the remaining number of devices in the booking that can be assigned
+        'remainingDevicesInBooking' >= 0 and <= 'totalDevicesInBooking'
+        - Once a device is successfully assigned to the booking, remainingNumDevices will be reduced by 1, and once the device is released then it will be incremented by 1
+        - Booking Information is also returned as part of the message body when the devices are successfully assigned to the booking. 
+        
+      allOf:
+        - type: object
+          properties:
+            bookingId:
+              $ref: "#/components/schemas/BookingId"
+            totalDevicesInBooking:
+              $ref: "#/components/schemas/DeviceCount"     
+            remainingDevicesInBooking:
+              $ref: "#/components/schemas/DeviceCount"                             
+            requestedBookingProfile:
+              $ref: "#/components/schemas/BookingProfile"         
+            status:
+              $ref: "#/components/schemas/Status"
+            statusInfo:
+              $ref: "#/components/schemas/StatusInfo"
+          required:
+            - bookingId
+            - totalDevicesInBooking
+            - remainingDevicesInBooking
+            - requestedBookingProfile
+
+    DeviceAssignmentInput:
+      description: Array of devices that needs to be assigned to a booking. The size of the array should be less than or equal to the devices that are remaining in the original booking 
+      type: object
+      properties:
+        bookingId:
+          $ref: "#/components/schemas/BookingId"
+        devices:
+          $ref: "#/components/schemas/Devices"
+        sink:
+          type: string
+          format: uri
+          description: The address to which events shall be delivered, using the HTTP protocol.
+          example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: "#/components/schemas/SinkCredential" 
+      required:
+        - bookingId
+  
+    DeviceAssignmentOutput :
+      description: |
+        Once the provision endpoint succcessful this output will be returend. It will have the BookingId along with all the originally requested information.
+      allOf:
+        - type: object
+          properties:
+            requestedBookingDetails:
+              $ref: "#/components/schemas/BookingOutput"
+            assignedDevices:
+              $ref: "#/components/schemas/Devices"         
+            status:
+              $ref: "#/components/schemas/AssignmentStatus"
+            statusInfo:
+              $ref: "#/components/schemas/AssignmentStatusInfo"
+
+    RetrieveBookingByDevice:
+      description: Attributes to look for QoS Booking
+      type: object
+      properties:
+        device:
+          $ref: "#/components/schemas/Device"
+
+    RetrieveBookingsOutput:
+      description: QoS bookings for a given device
+      type: array
+      items:
+        $ref: "#/components/schemas/BookingOutput"
+      minItems: 0
+
+    SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
+      type: object
+      properties:
+        credentialType:
+          type: string
+          enum:
+            - PLAIN
+            - ACCESSTOKEN
+            - REFRESHTOKEN
+          description: "The type of the credential."
+      discriminator:
+        propertyName: credentialType
+        mapping:
+          PLAIN: "#/components/schemas/PlainCredential"
+          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
+          REFRESHTOKEN: "#/components/schemas/RefreshTokenCredential"
+      required:
+        - credentialType
+
+    PlainCredential:
+      type: object
+      description: A plain credential as a combination of an identifier and a secret.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          required:
+            - identifier
+            - secret
+          properties:
+            identifier:
+              description: The identifier might be an account or username.
+              type: string
+            secret:
+              description: The secret might be a password or passphrase.
+              type: string
+
+    AccessTokenCredential:
+      type: object
+      description: An access token credential.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          properties:
+            accessToken:
+              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
+              type: string
+            accessTokenExpiresUtc:
+              type: string
+              format: date-time
+              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
+            accessTokenType:
+              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
+              type: string
+              enum:
+                - bearer
+          required:
+            - accessToken
+            - accessTokenExpiresUtc
+            - accessTokenType
+
+    RefreshTokenCredential:
+      type: object
+      description: An access token credential with a refresh token.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          properties:
+            accessToken:
+              description: REQUIRED. An access token is a previously acquired token granting access to the target resource.
+              type: string
+            accessTokenExpiresUtc:
+              type: string
+              format: date-time
+              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
+            accessTokenType:
+              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
+              type: string
+              enum:
+                - bearer
+            refreshToken:
+              description: REQUIRED. An refresh token credential used to acquire access tokens.
+              type: string
+            refreshTokenEndpoint:
+              type: string
+              format: uri
+              description: REQUIRED. A URL at which the refresh token can be traded for an access token.
+      required:
+        - accessToken
+        - accessTokenExpiresUtc
+        - accessTokenType
+        - refreshToken
+        - refreshTokenEndpoint
+
+    Port:
+      description: TCP or UDP port number
+      type: integer
+      minimum: 0
+      maximum: 65535
+
+    PortsSpec:
+      description: Specification of several TCP or UDP ports
+      type: object
+      minProperties: 1
+      properties:
+        ranges:
+          description: Range of TCP or UDP ports
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - from
+              - to
+            properties:
+              from:
+                $ref: "#/components/schemas/Port"
+              to:
+                $ref: "#/components/schemas/Port"
+        ports:
+          description: Array of TCP or UDP ports
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/Port"
+      example:
+        ranges:
+          - from: 5010
+            to: 5020
+        ports:
+          - 5060
+          - 5070
+
+    QosProfileName:
+      description: |
+        A unique name for identifying a specific QoS profile.
+        This may follow different formats depending on the service providers implementation.
+        Some options addresses:
+          - A UUID style string
+          - Support for predefined profiles QOS_S, QOS_M, QOS_L, and QOS_E
+          - A searchable descriptive name
+        The set of QoS Profiles that an operator is offering can be retrieved by means of the [QoS Profile API](link TBC).
+      type: string
+      example: QCI_1_voice
+      minLength: 3
+      maxLength: 256
+      format: string
+      pattern: "^[a-zA-Z0-9_.-]+$"
+
+    CloudEvent:
+      description: Event compliant with the CloudEvents specification
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - time
+      properties:
+        id:
+          description: Identifier of this event, that must be unique in the source context.
+          type: string
+        source:
+          description: Identifies the context in which an event happened in the specific Provider Implementation.
+          type: string
+          format: uri-reference
+        type:
+          description: The type of the event.
+          type: string
+          enum:
+            - "org.camaraproject.qos-booking-and-assignment.v0.status-changed"
+            - "org.camaraproject.qos-booking-and-assignment.v0.assignment-status-changed"
+        specversion:
+          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
+          type: string
+          enum:
+            - "1.0"
+        datacontenttype:
+          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+          type: string
+          enum:
+            - "application/json"
+        data:
+          description: Event notification details payload, which depends on the event type
+          type: object
+        time:
+          description: |
+            Timestamp of when the occurrence happened. It must follow RFC 3339
+          type: string
+          format: date-time
+      discriminator:
+        propertyName: "type"
+        mapping:
+          org.camaraproject.qos-booking-and-assignment.v0.status-changed: "#/components/schemas/EventStatusChanged"
+          org.camaraproject.qos-booking-and-assignment.v0.assignment-status-changed: "#/components/schemas/EventAssignmentStatusChanged"      
+          
+
+    EventStatusChanged:
+      description: Event to notify a QoS Booking status change
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: Event details depending on the event type
+              required:
+                - bookingId
+                - status
+              properties:
+                bookingId:
+                  $ref: "#/components/schemas/BookingId"       
+                status:
+                  $ref: "#/components/schemas/StatusChanged"
+                statusInfo:
+                  $ref: "#/components/schemas/StatusInfo"
+          required:
+            - data
+
+    EventAssignmentStatusChanged:
+      description: Event to notify a QoS Booking status change
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: Event details depending on the event type
+              required:
+                - status
+                - deviceDetails
+              properties:
+                deviceDetails:
+                  $ref: "#/components/schemas/DeviceAssignmentOutput"                
+                status:
+                  $ref: "#/components/schemas/StatusChanged"
+          required:
+            - data
+
+
+    Area:
+      description: Base schema for all areas
+      type: object
+      properties:
+        areaType:
+          $ref: "#/components/schemas/AreaType"
+      required:
+        - areaType
+      discriminator:
+        propertyName: areaType
+        mapping:
+          CIRCLE: "#/components/schemas/Circle"
+          POLYGON: "#/components/schemas/Polygon"
+
+    AreaType:
+      type: string
+      description: |
+        Type of this area.
+        CIRCLE - The area is defined as a circle.
+        POLYGON - The area is defined as a polygon.
+      enum:
+        - CIRCLE
+        - POLYGON
+
+    Circle:
+      description: Circular area
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - center
+            - radius
+          properties:
+            center:
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Distance from the center in meters
+              minimum: 1
+
+    Polygon:
+      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersect itself.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - boundary
+          properties:
+            boundary:
+              $ref: "#/components/schemas/PointList"
+
+    PointList:
+      description: List of points defining a polygon
+      type: array
+      items:
+        $ref: "#/components/schemas/Point"
+      minItems: 3
+      maxItems: 15
+
+    Point:
+      type: object
+      description: Coordinates (latitude, longitude) defining a location in a map
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example:
+        latitude: 50.735851
+        longitude: 7.10066
+
+    Latitude:
+      description: Latitude component of a location
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+
+    Longitude:
+      description: Longitude component of location
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
+
+    Device:
+      description: |
+        End-user equipment able to connect to the network. Examples of devices include smartphones or IoT sensors/actuators.
+
+        The developer can choose to provide the below specified device identifiers:
+
+        * `ipv4Address`
+        * `ipv6Address`
+        * `phoneNumber`
+        * `networkAccessIdentifier`
+
+        NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.
+        NOTE2: for the Commonalities release v0.4, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
+      type: object
+      properties:
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+        networkAccessIdentifier:
+          $ref: "#/components/schemas/NetworkAccessIdentifier"
+        ipv4Address:
+          $ref: "#/components/schemas/DeviceIpv4Addr"
+        ipv6Address:
+          $ref: "#/components/schemas/DeviceIpv6Address"
+      minProperties: 1
+
+    Time:
+      description: Date and time when the API consumer requests the QoS profile to become available. Format must follow RFC 3339 and must indicate time zone (UTC or local).
+      type: string
+      format: date-time
+      example: "2024-06-01T12:00:00Z"
+
+    Duration:
+      description: |
+        Requested session duration in seconds.  Value may be explicitly limited for the QoS profile, as specified in the Qos Profile (see qos-profile API). 
+        Implementations can grant the requested session duration or set a different duration from `startTime`, based on network policies or conditions.
+        We can make it optional with a default value of 24 hours. Also the user can ask any big number. But the actual value will be limitted by QoS Profile
+      type: integer
+      format: int32
+      minimum: 1
+      example: 3600
+      default: 86400
+
+    Devices:
+      description: Array of devices to be assigned to the booking and provisioned.  At least one device is required
+      type: array
+      minItems: 1
+      items:
+        $ref: "#/components/schemas/Device"
+
+    ApplicationServer:
+      description: |
+        A server hosting backend applications to deliver some business logic to clients.
+
+        The developer can choose to provide the below specified device identifiers:
+
+        * `ipv4Address`
+        * `ipv6Address`
+      type: object
+      properties:
+        ipv4Address:
+          $ref: "#/components/schemas/ApplicationServerIpv4Address"
+        ipv6Address:
+          $ref: "#/components/schemas/ApplicationServerIpv6Address"
+      minProperties: 1
+
+    ApplicationServerIpv4Address:
+      type: string
+      example: "198.51.100.0/24"
+      description: |
+        IPv4 address may be specified in form <address/mask> as:
+          - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
+          - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
+            In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
+
+    ApplicationServerIpv6Address:
+      type: string
+      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+      description: |
+        IPv6 address may be specified in form <address/mask> as:
+          - address - The /128 subnet is optional for single addresses:
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
+          - address/mask - an IP v6 number with a mask:
+            - 2001:db8:85a3:8d3::0/64
+            - 2001:db8:85a3:8d3::/64
+
+    NetworkAccessIdentifier:
+      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
+      type: string
+      example: "123456789@domain.com"
+
+    PhoneNumber:
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
+      type: string
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      example: "+123456789"
+
+    DeviceIpv4Addr:
+      type: object
+      description: |
+        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
+
+        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
+
+        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
+
+        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
+      properties:
+        publicAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        privateAddress:
+          $ref: "#/components/schemas/SingleIpv4Addr"
+        publicPort:
+          $ref: "#/components/schemas/Port"
+      anyOf:
+        - required: [publicAddress, privateAddress]
+        - required: [publicAddress, publicPort]
+      example:
+        {
+          "publicAddress": "203.0.113.0",
+          "publicPort": 59765
+        }
+
+    SingleIpv4Addr:
+      description: A single IPv4 address with no subnet mask
+      type: string
+      format: ipv4
+      example: "203.0.113.0"
+
+    DeviceIpv6Address:
+      description: |
+        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
+      type: string
+      format: ipv6
+      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    Status:
+      description: |
+        The current status of the requested QoS Booking. The status can be one of the following:
+        * `REQUESTED` - QoS booking has been requested but is still being processed.
+        * `SCHEDULED` - QoS booking has been granted for a future start time.
+        * 'AVAILABLE' - QoS booking is active and available 
+        * `UNAVAILABLE` - The QoS booking request has been processed but is not scheduled or active. `statusInfo` may provide additional information about the reason for the unavailability.
+        * 'CANCELLED' - Booking cancellation request is successful and the booking is cancelled. Booking ID will become invalid. 
+        * 'FAILED' - Cancellation request is failed. bookingId may be invalid, or already cancelled, or expired, or some other reason
+      enum:
+        - REQUESTED
+        - SCHEDULED
+        - AVAILABLE
+        - UNAVAILABLE
+        - CANCELLED
+        - FAILED
+
+    StatusChanged:
+      description: |
+        The current status of a requested, scheduled or previously available QoS Booking. Applicable values in the event are:
+        *  `SCHEDULED` - QoS booking has been granted for a future start time.
+        *  'ASSIGNED'  - Devices which are pending assignments are now assigned to the booking
+        *  `AVAILABLE` - The requested QoS profile has been activated for the device.
+        *  `UNAVAILABLE` - The QoS booking request has been processed but is not scheduled or active. `statusInfo` may provide additional information about the reason for the unavailability.
+      type: string
+      enum:
+        - SCHEDULED
+        - ASSIGNED
+        - AVAILABLE
+        - UNAVAILABLE
+
+    StatusInfo:
+      description: |
+        Reason for the new `status`. Currently `statusInfo` is only applicable when `status` is 'UNAVAILABLE' or REQUESTED or FAILED.
+        * `DURATION_EXPIRED` - Session terminated due to requested duration expired
+        * `NETWORK_TERMINATED` - Network terminated the QoS Booking for unknown reasons
+        * `DELETE_REQUESTED`- User requested the deletion of the QoS Booking
+        * 'VALIDATION_PENDING' - The validation is pending. The end user will get a callback with the availability of the booking
+        * 'SERVICE_NOT_AVAILABLE' - The requested booking could not be fullfilled because of operator could not support the service area/number of devices/qosProfile in the requested time
+        * 'QOS_PROFILE_NOT_SUPPORTED'  - The requested QoS Profile is not supported by the operator
+        * 'BOOKING_INVALID'  -  The given bookingId is invalid, malformed, or not available in the system
+        * 'BOOKING_CANCELLED'-  The given bookingId was cancelled by the user and is no more valid. 
+        * 'BOOKING_EXPIRED'  -  The given bookingId is expired and is no more valid
+
+      type: string
+      enum:
+        - DURATION_EXPIRED
+        - NETWORK_TERMINATED
+        - DELETE_REQUESTED
+        - VALIDATION_PENDING
+        - SERVICE_NOT_AVAILABLE
+        - QOS_PROFILE_NOT_SUPPORTED
+        - BOOKING_INVALID
+        - BOOKING_CANCELLED
+        - BOOKING_EXPIRED
+
+    AssignmentStatus:
+      description: |
+        The current status of the requested Device Assignement. This enums represent status specific to assignment. The status can be one of the following:
+        * `REQUESTED` - Device Assignment has been requested but is still being processed and pending assignments.
+        * `ASSIGNED` -  All Devices are assigned to booking and will be automatically provisioned at the scheduled time.
+        * 'PARTICAL_SUCCESS' - Some devices are assigned (or released), some devices are not. The return message will have details about the assigned devices
+        * 'RELEASED' -  Requested devices are released from booking. 
+        * 'FAILED' - Device release request is failed. device info may be invalid, or already cancelled, or booking is expired and not active, or some other reason
+      enum:
+        - ASSIGNED
+        - REQUESTED
+        - PARTIAL_SUCCESS
+        - CANCELLED
+        - FAILED
+
+    AssignmentStatusInfo:
+      description: |
+        If the status = REQUESTED, PARTIAL_SUCCESS, FAILED then this status info enums have additional information
+        * `DEVICE_NOT_FOUND` - One or some of the device are not found to validate and associate to booking. 
+        * 'QUOTA_EXCEEDED' - The number of devices requested to assign to a booking is more than the allocated totoal for the booking
+        * 'VALIDATION_PENDING' - The device assignment request is pending for validation and verification
+        * 'BOOKING_INVALID' - The user requests to release a device from booking, but the booking is invalid
+        * 'BOOKING_CANCELLED' - The user requests to release a device from booking, but the booking is cancelled
+        * 'BOOKING_EXPIRED' - The user requests to release a device from booking, but the booking is expiered and no more active
+
+      type: string
+      enum:
+        - DEVICE_NOT_FOUND
+        - QUOTA_EXCEEDED
+        - VALIDATION_PENDING
+        - BOOKING_INVALID
+        - BOOKING_CANCELLED
+        - BOOKING_EXPIRED
+
+
+    ErrorInfo:
+      description: Common schema for errors
+      type: object
+      properties:
+        status:
+          type: integer
+          description: HTTP status code returned along with this error response
+        code:
+          type: string
+          description: Code given to this error
+        message:
+          type: string
+          description: Detailed error description
+      required:
+        - status
+        - code
+        - message
+        
+    DeviceCount:
+      description: | 
+        Number of devices that may be assigned to booking. The default value is 1.
+      type: integer
+      minimum: 1
+      default: 1
+
+
+  responses:
+    Generic400:
+      description: Bad Request
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
+
+    CreateBooking400:
+      description: Bad Request when creating a QoS booking.
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - QOS_BOOKING.DURATION_OUT_OF_RANGE
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
+            DurationOutOfRangeForQoSProfile:
+              description: The requested duration is out of the allowed range for the specific QoS profile
+              value:
+                status: 400
+                code: QOS_BOOKING.DURATION_OUT_OF_RANGE
+                message: The requested duration is out of the allowed range for the specific QoS profile
+            GENERIC_400_INVALID_CREDENTIAL:
+              value:
+                status: 400
+                code: INVALID_CREDENTIAL
+                message: Only Access token is supported
+            GENERIC_400_INVALID_TOKEN:
+              value:
+                status: 400
+                code: INVALID_TOKEN
+                message: Only bearer token is supported
+
+    Generic401:
+      description: Unauthorized
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+          examples:
+            GENERIC_401_UNAUTHENTICATED:
+              description: Request cannot be authenticated
+              value:
+                status: 401
+                code: UNAUTHENTICATED
+                message: Request not authenticated due to missing, invalid, or expired credentials.
+
+    Generic403:
+      description: Forbidden
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
+
+    Generic404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+
+    GenericDevice404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_DEVICE_NOT_FOUND:
+              description: Device identifier not found
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Device identifier not found.
+
+    BookingConflict409:
+      description: Conflict
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - CONFLICT
+          example:
+            status: 409
+            code: CONFLICT
+            message: Conflict with an existing booking for the same device.
+
+    Generic410:
+      description: Gone
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
+          examples:
+            GENERIC_410_GONE:
+              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
+              value:
+                status: 410
+                code: GONE
+                message: Access to the target resource is no longer available.
+
+    Generic422:
+      description: Unprocessable Content
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+          examples:
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
+              value:
+                status: 422
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
+
+    Generic429:
+      description: Too Many Requests
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
+          examples:
+            GENERIC_429_QUOTA_EXCEEDED:
+              description: Request is rejected due to exceeding a business quota limit
+              value:
+                status: 429
+                code: QUOTA_EXCEEDED
+                message: Out of resource quota.
+            GENERIC_429_TOO_MANY_REQUESTS:
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
+              value:
+                status: 429
+                code: TOO_MANY_REQUESTS
+                message: Rate limit reached.
+
+  examples:
+    BOOKING_AVAILABLE:
+      summary: QoS booking status is available
+      description: QoS booking info when status is available
+      value:
+        bookingId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        duration: 3600
+        device:
+          ipv4Address:
+            publicAddress: "203.0.113.0"
+            publicPort: 59765
+        qosProfile: "QOS_L"
+        sink: "https://application-server.com/notifications"
+        startTime: "2024-06-01T12:00:00Z"
+        startedAt: "2024-06-01T12:00:00Z"
+        status: "AVAILABLE"
+        serviceArea:
+          areaType: "CIRCLE"
+          center:
+            latitude: 50.735851
+            longitude: 7.10066
+          radius: 100
+
+    BOOKING_UNAVAILABLE:
+      summary: QoS booking is unavailable
+      description: QoS booking info when status is unavailable due to network termination
+      value:
+        bookingId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        duration: 2428
+        qosProfile: "Acme2"
+        sink: "https://application-server.com/notifications"
+        startTime: "2024-06-01T12:00:00Z"
+        startedAt: "2024-06-01T12:00:00Z"
+        status: "UNAVAILABLE"
+        serviceArea:
+          areaType: "CIRCLE"
+          center:
+            latitude: 50.735851
+            longitude: 7.10066
+          radius: 100
+        statusInfo: "NETWORK_TERMINATED"
+
+    BOOKING_STATUS_CHANGED_EXAMPLE:
+      summary: Booking status changed
+      description: Cloud event example for status change to UNAVAILABLE due to DURATION_EXPIRED
+      value:
+        id: "83a0d986-0866-4f38-b8c0-fc65bfcda452"
+        source: "https://api.example.com/qod/v1/sessions/123e4567-e89b-12d3-a456-426614174000"
+        specversion: "1.0"
+        type: "org.camaraproject.qos-booking-and-assignment.v0.status-changed"
+        time: "2024-06-01T13:00:00Z"
+        data:
+          bookingId: "123e4567-e89b-12d3-a456-426614174000"
+          status: "UNAVAILABLE"
+          statusInfo: "DURATION_EXPIRED"
+
+    RETRIEVE_BOOKINGS_ONE_ITEM:
+      summary: List of QoS sessions for the device
+      description: A single QoS session for the device is available
+      value:
+        - bookingId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          duration: 3600
+          device:
+            phoneNumber: "+123456789"
+          applicationServer:
+            ipv4Address: "0.0.0.0/0"
+          qosProfile: "QOS_L"
+          sink: "https://application-server.com/notifications"
+          startTime: "2024-06-01T12:00:00Z"
+          startedAt: "2024-06-01T12:00:00Z"
+          status: "AVAILABLE"
+          serviceArea:
+            areaType: "CIRCLE"
+            center:
+              latitude: 50.735851
+              longitude: 7.10066
+            radius: 100
+
+    RETRIEVE_BOOKINGS_NO_ITEMS:
+      summary: No bookings found for the device
+      description: An empty array is returned when no bookings are found for the device
+      value: []

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -80,6 +80,8 @@ servers:
 tags:
   - name: QoS Booking
     description: Manage the booking of QoS
+  - name: Device QoS Assignment
+    description: Manage the assignment of devices of QoS
 
 paths:
   /device-qos-bookings:
@@ -332,6 +334,133 @@ paths:
         - openId:
             - "qos-booking:device-qos-bookings:retrieve-by-device"
 
+  /device-qos-assignment:
+    post:
+      tags:
+        - Device QoS Assignment
+      summary: Assign (also called as Provision) one or more devices to the existing QoS Booking
+      description: |
+        This end-point allows the user to assign (provision) one or more devices to the exisitng QoS Booking. 
+        status = 'AVAILABLE' if the provision is successful and the network is available for the said devices to connect and use them at the requested time 
+        status = 'UNAVAILABLE'  if the provision is unsuccessful and the StatusInfo will have more information.
+        This is an asynchronus call and status = REQUESTED, if the network is still working on your request and a callback will come with appropriate status. 
+        
+      operationId: provisionQoS
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to create a new booking
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProvisionInput"
+        required: true
+      callbacks:
+        notifications:
+          "{$request.body#/sink}":
+            post:
+              summary: Booking notifications callback
+              description: |
+                Important: this endpoint is to be implemented by the API consumer.
+                The API provider will call this endpoint whenever any QoS Provisioning change related event occurs.
+              operationId: postBookingNotification
+              parameters:
+                - $ref: "#/components/parameters/x-correlator"
+              requestBody:
+                required: true
+                content:
+                  application/cloudevents+json:
+                    schema:
+                      $ref: "#/components/schemas/CloudEvent"
+              responses:
+                "204":
+                  description: Successful notification
+                  headers:
+                    x-correlator:
+                      $ref: "#/components/headers/x-correlator"
+                "400":
+                  $ref: "#/components/responses/Generic400"
+                "401":
+                  $ref: "#/components/responses/Generic401"
+                "403":
+                  $ref: "#/components/responses/Generic403"
+                "410":
+                  $ref: "#/components/responses/Generic410"
+              security:
+                - {}
+                - notificationsBearerAuth: []
+      responses:
+        "201":
+          description: At least one device is assigned to the booking. The developer can call this endpoint mulitple times with appropriate information
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProvisionOutput"
+        "400":
+          $ref: "#/components/responses/CreateBooking400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "409":
+          $ref: "#/components/responses/BookingConflict409"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking:provision-qos-bookings:create"
+
+  /device-qos-release:
+    post:
+      tags:
+        - Device QoS Assignment
+      summary: Release one or more devices from the given QoS Booking
+      description: Release one or more already assigned devices. This is a synchronous call.  If this call fails, the developer can call again with appropriate device info,
+      operationId: deleteQoS
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        description: Parameters to release devices
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProvisionInput"
+        required: true
+      responses:
+        "201":
+          description: Release of devices successful
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProvisionOutput"
+        "400":
+          $ref: "#/components/responses/CreateBooking400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/GenericDevice404"
+        "409":
+          $ref: "#/components/responses/BookingConflict409"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
+      security:
+        - openId:
+            - "qos-booking:provision-qos-bookings:create"
+
 components:
   securitySchemes:
     openId:
@@ -475,7 +604,92 @@ components:
             - startTime
             - duration
             - serviceArea
-            
+  
+    BookingDetails: 
+      description: |
+        These are the booking details that will be returned once the booking is successful.
+        It returns original number of devices that are requested as well as the remaining number of devices in the booking that can be assigned
+        remainingNumDevices >= 0 and <= requestedNumDevices
+        Once a device is successfully assigned to the booking, remainingNumDevices will reduced by 1, and once the device is released then it will be incremented by 1
+        If the device is already assigned no action will be taken
+      allOf:
+        - type: object
+          properties:
+            bookingId:
+              $ref: "#/components/schemas/BookingId"
+            requestedNumDevices:
+              $ref: "#/components/schemas/NumDevices"     
+            remainingNumDevices:
+              $ref: "#/components/schemas/NumDevices"                             
+            qosProfile:
+              $ref: "#/components/schemas/QosProfileName"
+            startTime:
+              description: Date and time when the API consumer requests the QoS profile to become available. Format must follow RFC 3339 and must indicate time zone (UTC or local).
+              type: string
+              format: date-time
+              example: "2024-06-01T12:00:00Z"
+            duration:
+              description:
+                Requested session duration in seconds.  Value may be explicitly limited for the QoS profile, as specified in the Qos Profile (see qos-profile API). 
+                Implementations can grant the requested session duration or set a different duration from `startTime`, based on network policies or conditions.
+                We can make it optional with a default value of 24 hours. Also the user can ask any big number. But the actual value will be limitted by QoS Profile
+              type: integer
+              format: int32
+              minimum: 1
+              example: 3600
+              default: 86400
+            serviceArea:
+              $ref: "#/components/schemas/Area"          
+          required:
+            - bookingId
+            - requestedNumDevices
+            - remainingNumDevices
+            - qosProfile
+            - startTime
+            - duration
+            - serviceArea 
+
+    ProvisionInput:
+      description: Array of devices that needs to be assigned to a booking. 
+      type: object
+      properties:
+        bookingId:
+          $ref: "#/components/schemas/BookingId"
+        devices:
+          type: array
+          description: Array of devices to be provisioned.  At least one device is required
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/Device"
+        sink:
+          type: string
+          format: uri
+          description: The address to which events shall be delivered, using the HTTP protocol.
+          example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: "#/components/schemas/SinkCredential" 
+      required:
+        - bookingId
+  
+    ProvisionOutput :
+      description: |
+        Once the provision endpoint succcessful this output will be returend. It will have the BookingId along with all the originally requested information.
+      allOf:
+        - type: object
+          properties:
+            bookingDetails:
+              $ref: "#/components/schemas/BookingDetails"
+            devices:
+              type: array
+              description: Array of devices that are actually provisioned. 
+              minItems: 0
+              items:
+                $ref: "#/components/schemas/Device"         
+            status:
+              $ref: "#/components/schemas/Status"
+            statusInfo:
+              $ref: "#/components/schemas/StatusInfo"
+
     RetrieveBookingByDevice:
       description: Attributes to look for QoS Booking
       type: object
@@ -711,12 +925,19 @@ components:
         * `DURATION_EXPIRED` - Session terminated due to requested duration expired
         * `NETWORK_TERMINATED` - Network terminated the QoS Booking
         * `DELETE_REQUESTED`- User requested the deletion of the QoS Booking
+        * 'DEVICES_MORE_THAN_REQUESTED' - Number of devices requested to provision exceeds the actual number of devices booked in advance
+        * 'BOOKING_INVALID'  -  The given bookingId is invalid, or not availlable to provision devices
+        * 'BOOKING_EXPIRED'  -  The given bookingId is expired
+
 
       type: string
       enum:
         - DURATION_EXPIRED
         - NETWORK_TERMINATED
         - DELETE_REQUESTED
+        - DEVICES_MORE_THAN_REQUESTED
+        - BOOKING_INVALID
+        - BOOKING_EXPIRED
 
     Area:
       description: Base schema for all areas

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -429,6 +429,8 @@ components:
               example: 3600
             serviceArea:
               $ref: "#/components/schemas/Area"
+            numDevices:
+              $ref: "#/components/schemas/NumDevices"  
             bookingId:
               $ref: "#/components/schemas/BookingId"
             startedAt:
@@ -467,6 +469,8 @@ components:
               example: 3600
             serviceArea:
               $ref: "#/components/schemas/Area"
+            numDevices:
+              $ref: "#/components/schemas/NumDevices"  
           required:
             - startTime
             - duration
@@ -956,6 +960,17 @@ components:
         - status
         - code
         - message
+        
+  # This schema is added to suport experiemental parameter numDevices and could change or would be removed in the future
+    NumDevices:
+      description: | 
+        Maximum Number of devices that can be provisioned. The default value is 1.
+        ** Note **:  NumDevices (and numDevices) is experimental and could change or would be removed in the future
+        if number of devices is more than 1, the device information SHOULD NOT be provided as part of CreateBooking
+      type: integer
+      minimum: 1
+      default: 1
+
 
   responses:
     Generic400:


### PR DESCRIPTION
The current changes are to support QoS booking for multiple devices at once.

#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature



#### What this PR does / why we need it:

This PR allows the user to book QoS for multiple devices at once


#### Which issue(s) this PR fixes:
<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #12 

#### Special notes for reviewers:



#### Changelog input

```
 release-note


1. Added NumDevices Schema
2. Added numDevices property in CreateBooking
3. Added numDevices property in BookingInfo

```
#### Additional documentation 

This section can be blank.



```
docs

```
