### PR TITLE
Reset versions in API and test definitions back to wip after r1.1

### DIFF
--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -77,7 +77,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -85,7 +85,7 @@ externalDocs:
   url: https://github.com/camaraproject/QoSBooking
 
 servers:
-  - url: "{apiRoot}/qos-booking-and-assignment/v0.1rc1"
+  - url: "{apiRoot}/qos-booking-and-assignment/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -69,7 +69,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
@@ -77,7 +77,7 @@ externalDocs:
   url: https://github.com/camaraproject/QoSBooking
 
 servers:
-  - url: "{apiRoot}/qos-booking/v0.1rc1"
+  - url: "{apiRoot}/qos-booking/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/qos-booking-and-assignment.feature
+++ b/code/Test_definitions/qos-booking-and-assignment.feature
@@ -1,5 +1,5 @@
 
-Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
+Feature: CAMARA QoS Booking and Assignment, vwip
     # Input to be provided by the implementation to the tester
     # References to OAS spec schemas refer to schemas specified in qos-booking-and-assignment.yaml
 
@@ -12,7 +12,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     # Reserve a set of devices for a given qos profile, service area, scheduled future time and duration
     @qos_bookings_createBooking_201_success
     Scenario: Create a QoS booking with valid parameters
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings"
         And the header "Content-Type" is set to "application/json"
         And the operationId is "createBooking"
         And the request body is set to a request body compliant with the schema at "/components/schemas/BookingInput"
@@ -46,7 +46,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     # Given a bookingID, this GET operation gets the details of the original booking
     @qos_bookings_getBookingById_200_success
     Scenario: Get an existing QoS booking by bookingId
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings"
         And an existing QoS booking with "bookingId" is created by the operation "createBooking"
         And the operationId is "getBookingById"
 
@@ -72,7 +72,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     # This operation deletes a booking identified by bookingID. 
     @qos_bookings_deleteBooking_200_success
     Scenario: Delete a QoS booking
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings"
         And "bookingId" is created by operation "createBooking"
         And the operationId is "deleteBooking"
 
@@ -99,7 +99,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     @devices_assignDevices_201_success
     Scenario: Assign a set of devices to a QoS booking
 
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings/{bookingId}/devices/assign"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings/{bookingId}/devices/assign"
         And the "bookingId" is created by operation "createBooking"
         And the operationId is "assignDevices"
         And the request body complies with the OAS schema at "/components/schemas/DeviceAssignmentInput"
@@ -125,7 +125,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     @devices_releaseDevices_200_success
     Scenario: Release one or more of already assigned devices from a QoS booking
 
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings/{bookingId}/devices/release"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings/{bookingId}/devices/release"
         And the "bookingId" is created by operation "createBooking"
         And the operationId is "releaseDevices"
         And the request body complies with the OAS schema at "/components/schemas/DeviceAssignmentInput"
@@ -151,7 +151,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     @devices_getDevicesByBookingId_200_success
     Scenario: Get a list of devices assigned to a QoS booking
 
-        Given the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings/{bookingId}/devices"
+        Given the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings/{bookingId}/devices"
         And the "bookingId" is created by operation "createBooking"
         And the operationId is "getDevicesByBookingId"
  
@@ -172,7 +172,7 @@ Feature: CAMARA QoS Booking and Assignment, v0.1.0-rc.1
     @devices_retrieveBooking_200_success
     Scenario: Get QoS Booking resource information details for a device
         Given a valid testing device with an existing QoS Booking, identified by the token or provided in the request body
-        And the resource "{apiRoot}/qos-booking-and-assignment/v0.1rc1/qos-bookings/retrieve"
+        And the resource "{apiRoot}/qos-booking-and-assignment/vwip/qos-bookings/retrieve"
 
         When the request "retrieveBookingByDevice" is sent
         Then the response status code is 200

--- a/code/Test_definitions/qos-booking.feature
+++ b/code/Test_definitions/qos-booking.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA QoS Booking API, v0.1.0-rc.1 - API Operations
+Feature: CAMARA QoS Booking API, vwip - API Operations
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -26,7 +26,7 @@ Feature: CAMARA QoS Booking API, v0.1.0-rc.1 - API Operations
 
     @qos_booking_createBooking_01_success
     Scenario: Create a QoS booking with valid parameters
-        Given the resource "/qos-booking/v0.1rc1/device-qos-bookings"
+        Given the resource "/qos-booking/vwip/device-qos-bookings"
         And the header "Content-Type" is set to "application/json"
         And the request body is set to a request body compliant with the schema at "/components/schemas/CreateBooking"
         And the request body property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
@@ -52,7 +52,7 @@ Feature: CAMARA QoS Booking API, v0.1.0-rc.1 - API Operations
 
     @qos_booking_getBooking_01_success
     Scenario: Get an existing QoS booking by bookingId
-        Given the resource "/qos-booking/v0.1rc1/device-qos-bookings/{bookingId}"
+        Given the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
         And an existing QoS booking created by operation createBooking
         And the path parameter "bookingId" is set to the value for that QoS booking
         When the request "getBookingById" is sent
@@ -74,7 +74,7 @@ Feature: CAMARA QoS Booking API, v0.1.0-rc.1 - API Operations
     Scenario: Delete a QoS booking
         Given that implementation deletes QoS booking synchronously
         And an existing QoS booking created by operation createBooking
-        And the resource "/qos-booking/v0.1rc1/device-qos-bookings/{bookingId}"
+        And the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
         And the path parameter "bookingId" is set to the value for that QoS booking
         When the request "deleteBooking" is sent
         Then the response status code is 204
@@ -85,7 +85,7 @@ Feature: CAMARA QoS Booking API, v0.1.0-rc.1 - API Operations
     @qos_booking_retrieveBooking_01_success
     Scenario: Get QoS Booking resource information details for a device
         Given a valid testing device with an existing QoS Booking, identified by the token or provided in the request body
-        And the resource "/qos-booking/v0.1rc1/retrieve-device-qos-bookings"
+        And the resource "/qos-booking/vwip/retrieve-device-qos-bookings"
         When the request "retrieveBookingByDevice" is sent
         Then the response status code is 200
         And the response header "Content-Type" is "application/json"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* repository management

#### What this PR does / why we need it:

Setting the version in API and test definitions back to wip after r1.1 to clearly indicate that any change done between r1.1 and r1.2 does not belong to neither of the releases. 

That will allow to address open issues with PRs without taking care of the version field.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # none (repository management)

#### Special notes for reviewers:

Good practice as done within QualityOnDemand in the past (see for example https://github.com/camaraproject/QualityOnDemand/pull/421)

