### PR TITLE
Fix files of qos-booking for compliance with centralised linting rules

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -418,7 +418,7 @@ components:
         - type: object
           properties:
             device:
-              $ref: "#/components/schemas/DeviceResponse"            
+              $ref: "#/components/schemas/DeviceResponse"
             startTime:
               description: Date and time when QoS profile is scheduled to become available. Format must follow RFC 3339 and must indicate time zone (UTC or local).
               type: string
@@ -475,7 +475,7 @@ components:
             - startTime
             - duration
             - serviceArea
-            
+
     RetrieveBookingByDevice:
       description: Attributes to look for QoS Booking
       type: object
@@ -987,7 +987,7 @@ components:
       type: string
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-      
+
   responses:
     Generic400:
       description: Bad Request
@@ -1351,7 +1351,7 @@ components:
                 status: 422
                 code: QOS_BOOKING.INVALID_AREA
                 message: "The requested area is too small"
-                
+
     Generic429:
       description: Too Many Requests
       headers:
@@ -1467,3 +1467,4 @@ components:
       summary: No bookings found for the device
       description: An empty array is returned when no bookings are found for the device
       value: []
+

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: QoS Booking API
+  title: QoS Booking
   description: |
     The QoS (Quality of Service) Booking API provides programmable interface for developers and other users (capabilities consumers) to request in advance certain network conditions to be provided by Telco networks, without the necessity to have an in-depth knowledge of the underlying network complexity (e.g. the 4G/5G system in case of a mobile network).
 

--- a/code/Test_definitions/qos-booking.feature
+++ b/code/Test_definitions/qos-booking.feature
@@ -25,7 +25,7 @@ Feature: CAMARA QoS Booking API, vwip - API Operations
   # Success scenarios for POST /device-qos-bookings
 
   @qos_booking_createBooking_01_success
-  Scenario: Create a QoS booking
+  Scenario: Create a QoS booking with valid parameters
     Given the resource "/qos-booking/vwip/device-qos-bookings"
     And the header "Content-Type" is set to "application/json"
     And the request body is set to a request body compliant with the schema at "/components/schemas/CreateBooking"
@@ -33,18 +33,11 @@ Feature: CAMARA QoS Booking API, vwip - API Operations
     And the request body property "$.startTime" is set to a valid time
     And the request body property "$.duration" is set to a valid duration for the selected QoS profile
     And the request body property "$.serviceArea" is set to a valid service area
-    And the request body property "$.sink" is set to a valid notification URL
-    And the request body property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
     When the request "createBooking" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "/components/schemas/BookingInfo"
-    And the response body property "$.qosProfile" has the same value as in the request body
-    And the response body property "$.startTime" has the same value as in the request body
-    And the response body property "$.duration" has the same value as in the request body
-    And the response body property "$.serviceArea" has the same value as in the request body
-    And the response body property "$.sink" exists only if provided in the request body and with the same value
     And the response body property "$.bookingId" exists and is a valid UUID
     And the response body property "$.status" is "REQUESTED"
 

--- a/code/Test_definitions/qos-booking.feature
+++ b/code/Test_definitions/qos-booking.feature
@@ -17,85 +17,84 @@ Feature: CAMARA QoS Booking API, vwip - API Operations
     #
     # References to OAS spec schemas refer to schemas specified in qos-booking.yaml
 
-    Background: Common QoS Booking setup
-        Given an environment at "apiRoot"
-        And the header "Authorization" is set to a valid access token
-        And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+  Background: Common QoS Booking setup
+    Given an environment at "apiRoot"
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
-    # Success scenarios for POST /device-qos-bookings
+  # Success scenarios for POST /device-qos-bookings
 
-    @qos_booking_createBooking_01_success
-    Scenario: Create a QoS booking with valid parameters
-        Given the resource "/qos-booking/vwip/device-qos-bookings"
-        And the header "Content-Type" is set to "application/json"
-        And the request body is set to a request body compliant with the schema at "/components/schemas/CreateBooking"
-        And the request body property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
-        And the request body property "$.startTime" is set to a valid time
-        And the request body property "$.duration" is set to a valid duration for the selected QoS profile
-        And the request body property "$.serviceArea" is set to a valid service area
-        And the request body property "$.sink" is set to a valid notification URL
-        And the request body property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
-        When the request "createBooking" is sent
-        Then the response status code is 201
-        And the response header "Content-Type" is "application/json"
-        And the response header "x-correlator" has the same value as the request header "x-correlator"
-        And the response body complies with the OAS schema at "/components/schemas/BookingInfo"
-        And the response body property "$.qosProfile" has the same value as in the request body
-        And the response body property "$.startTime" has the same value as in the request body
-        And the response body property "$.duration" has the same value as in the request body
-        And the response body property "$.serviceArea" has the same value as in the request body
-        And the response body property "$.sink" exists only if provided in the request body and with the same value
-        And the response body property "$.bookingId" exists and is a valid UUID
-        And the response body property "$.status" is "REQUESTED"
+  @qos_booking_createBooking_01_success
+  Scenario: Create a QoS booking
+    Given the resource "/qos-booking/vwip/device-qos-bookings"
+    And the header "Content-Type" is set to "application/json"
+    And the request body is set to a request body compliant with the schema at "/components/schemas/CreateBooking"
+    And the request body property "$.qosProfile" is set to a valid QoS Profile as returned by QoS Profiles API
+    And the request body property "$.startTime" is set to a valid time
+    And the request body property "$.duration" is set to a valid duration for the selected QoS profile
+    And the request body property "$.serviceArea" is set to a valid service area
+    And the request body property "$.sink" is set to a valid notification URL
+    And the request body property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
+    When the request "createBooking" is sent
+    Then the response status code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/BookingInfo"
+    And the response body property "$.qosProfile" has the same value as in the request body
+    And the response body property "$.startTime" has the same value as in the request body
+    And the response body property "$.duration" has the same value as in the request body
+    And the response body property "$.serviceArea" has the same value as in the request body
+    And the response body property "$.sink" exists only if provided in the request body and with the same value
+    And the response body property "$.bookingId" exists and is a valid UUID
+    And the response body property "$.status" is "REQUESTED"
 
-    # Success scenarios for GET /device-qos-bookings/{bookingId}
+  # Success scenarios for GET /device-qos-bookings/{bookingId}
 
-    @qos_booking_getBooking_01_success
-    Scenario: Get an existing QoS booking by bookingId
-        Given the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
-        And an existing QoS booking created by operation createBooking
-        And the path parameter "bookingId" is set to the value for that QoS booking
-        When the request "getBookingById" is sent
-        Then the response status code is 200
-        And the response header "Content-Type" is "application/json"
-        And the response header "x-correlator" has the same value as the request header "x-correlator"
-        And the response body complies with the OAS schema at "/components/schemas/BookingInfo"
-        # Additionally any success response has to comply with some constraints beyond the schema compliance
-        And the response body property "$.device" exists only if provided for createBooking and with the same value
-        And the response body property "$.qosProfile" has the value provided for createBooking
-        And the response body property "$.startTime" has the value provided for createBooking
-        And the response body property "$.duration" has the value provided for createBooking
-        And the response body property "$.serviceArea" has the value provided for createBooking
-        And the response body property "$.sink" exists only if provided for createBooking and with the same value
+  @qos_booking_getBooking_01_success
+  Scenario: Get an existing QoS booking by bookingId
+    Given the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
+    And an existing QoS booking created by operation createBooking
+    And the path parameter "bookingId" is set to the value for that QoS booking
+    When the request "getBookingById" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/BookingInfo"
+    # Additionally any success response has to comply with some constraints beyond the schema compliance
+    And the response body property "$.device" exists only if provided for createBooking and with the same value
+    And the response body property "$.qosProfile" has the value provided for createBooking
+    And the response body property "$.startTime" has the value provided for createBooking
+    And the response body property "$.duration" has the value provided for createBooking
+    And the response body property "$.serviceArea" has the value provided for createBooking
+    And the response body property "$.sink" exists only if provided for createBooking and with the same value
 
-    # Success scenarios for DELETE /device-qos-bookings/{bookingId}
+  # Success scenarios for DELETE /device-qos-bookings/{bookingId}
 
-    @qos_booking_deleteBooking_01_success
-    Scenario: Delete a QoS booking
-        Given that implementation deletes QoS booking synchronously
-        And an existing QoS booking created by operation createBooking
-        And the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
-        And the path parameter "bookingId" is set to the value for that QoS booking
-        When the request "deleteBooking" is sent
-        Then the response status code is 204
-        And the response header "x-correlator" has the same value as the request header "x-correlator"
+  @qos_booking_deleteBooking_01_success
+  Scenario: Delete a QoS booking
+    Given that implementation deletes QoS booking synchronously
+    And an existing QoS booking created by operation createBooking
+    And the resource "/qos-booking/vwip/device-qos-bookings/{bookingId}"
+    And the path parameter "bookingId" is set to the value for that QoS booking
+    When the request "deleteBooking" is sent
+    Then the response status code is 204
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
 
-    # Success scenarios for POST /retrieve-device-qos-bookings
+  # Success scenarios for POST /retrieve-device-qos-bookings
 
-    @qos_booking_retrieveBooking_01_success
-    Scenario: Get QoS Booking resource information details for a device
-        Given a valid testing device with an existing QoS Booking, identified by the token or provided in the request body
-        And the resource "/qos-booking/vwip/retrieve-device-qos-bookings"
-        When the request "retrieveBookingByDevice" is sent
-        Then the response status code is 200
-        And the response header "Content-Type" is "application/json"
-        And the response header "x-correlator" has the same value as the request header "x-correlator"
-        And the response body complies with the OAS schema at "/components/schemas/RetrieveBookingsOutput"
-        # Additionally any success response has to comply with some constraints beyond the schema compliance
-        And the response body property "$.device" exists only if provided for createBooking and with the same value
-        And the response body property "$.qosProfile" has the value provided for createBooking
-        And the response body property "$.startTime" has the value provided for createBooking
-        And the response body property "$.duration" has the value provided for createBooking
-        And the response body property "$.serviceArea" has the value provided for createBooking
-        And the response body property "$.sink" exists only if provided for createBooking and with the same value
-
+  @qos_booking_retrieveBooking_01_success
+  Scenario: Get QoS Booking resource information details for a device
+    Given a valid testing device with an existing QoS Booking, identified by the token or provided in the request body
+    And the resource "/qos-booking/vwip/retrieve-device-qos-bookings"
+    When the request "retrieveBookingByDevice" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "/components/schemas/RetrieveBookingsOutput"
+    # Additionally any success response has to comply with some constraints beyond the schema compliance
+    And the response body property "$.device" exists only if provided for createBooking and with the same value
+    And the response body property "$.qosProfile" has the value provided for createBooking
+    And the response body property "$.startTime" has the value provided for createBooking
+    And the response body property "$.duration" has the value provided for createBooking
+    And the response body property "$.serviceArea" has the value provided for createBooking
+    And the response body property "$.sink" exists only if provided for createBooking and with the same value


### PR DESCRIPTION
#### What type of PR is this?
* correction
* tests

#### What this PR does / why we need it:
Some changes are required to the yaml and feature files of qos-booking for compliance with centralised linting rules. Mostly indentation changes and removal of spare spaces.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for reviewers:
Needs to be merged before PR https://github.com/camaraproject/QoSBooking/pull/38


#### Changelog input
```
 release-note
- Fix feature files for compliance with centralised linting rules
```

#### Additional documentation 
None