### PR TITLE
Update qos-booking-and-assignment.yaml to support issues in #36

### DIFF
--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -591,7 +591,6 @@ components:
           required:
             - qosProfile
             - startTime
-            - duration
             - serviceArea
 
     BookingDetails: 
@@ -621,7 +620,6 @@ components:
             - remainingDevicesInBooking
             - qosProfile
             - startTime
-            - duration
             - serviceArea
     
     BookingOutput: 
@@ -659,7 +657,6 @@ components:
             - remainingDevicesInBooking
             - qosProfile
             - startTime
-            - duration
             - serviceArea
             - status
   
@@ -1131,6 +1128,7 @@ components:
         * `SUCCESSFUL` - The request is processed successfully. This may happen immediately.  The state will go to PENDING and then back to SUCCESSFUL in certain conditions.ƒ
         * `PARTIAL_SUCCESS` -  The request is processed with partial success - applicable to device assignments.  'statusInfo' may have additional information. This enum is optional, and useful if the operator wants to communicate partial success.
         * `FAILURE` - The request has been processed but failed. `statusInfo` may provide additional information about the reason for the unavailability.
+      type: string
       enum:
         - PENDING
         - SUCCESSFUL
@@ -1561,3 +1559,4 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
+

--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -591,6 +591,7 @@ components:
           required:
             - qosProfile
             - startTime
+            - duration
             - serviceArea
 
     BookingDetails: 
@@ -620,6 +621,7 @@ components:
             - remainingDevicesInBooking
             - qosProfile
             - startTime
+            - duration
             - serviceArea
     
     BookingOutput: 
@@ -657,6 +659,7 @@ components:
             - remainingDevicesInBooking
             - qosProfile
             - startTime
+            - duration
             - serviceArea
             - status
   
@@ -1056,7 +1059,6 @@ components:
       format: int32
       minimum: 1
       example: 3600
-      default: 86400
 
     Devices:
       description: | 
@@ -1559,4 +1561,5 @@ components:
                 status: 429
                 code: TOO_MANY_REQUESTS
                 message: Rate limit reached.
+
 


### PR DESCRIPTION
1. Fixed the type issue in Status and 2. duration is now optional in all definitions.

#### What type of PR is this?

* bug



#### What this PR does / why we need it:

Fixes type issue in 'Status' and make duration field optional


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #36 

#### Special notes for reviewers:



#### Changelog input

```
Fixes type issue in 'Status' and make duration field optional

```

#### Additional documentation 

This section can be blank.



```
docs

```
