### PR TITLE
QoS B: update of request parameter for serviceArea

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -795,7 +795,7 @@ components:
           properties:
             areaId:
               type: string
-              format: uuid              
+              format: uuid
 
     AreaName:
       description: The value of "AreaName" might be predefined and only regional or even an operator-specific in this API version. As a prerequisite, the API Provider may offer API Consumer the "AreaName" values, which API consumer can request, in a preparation phase. And then API Consumers can select from the "AreaNames" as Service Areas.

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -742,6 +742,7 @@ components:
         mapping:
           CIRCLE: "#/components/schemas/Circle"
           POLYGON: "#/components/schemas/Polygon"
+          AREAID: "#/components/schemas/AreaId"
           AREANAME: "#/components/schemas/AreaName"
 
     AreaType:
@@ -750,10 +751,12 @@ components:
         Type of this area.
         CIRCLE - The area is defined as a circle.
         POLYGON - The area is defined as a polygon.
+        AREAID - The area is defined as an area ID.
         AREANAME - The area is defined as an area name.
       enum:
         - CIRCLE
         - POLYGON
+        - AREAID
         - AREANAME
 
     Circle:
@@ -782,6 +785,17 @@ components:
           properties:
             boundary:
               $ref: "#/components/schemas/PointList"
+    AreaId:
+      description: The area is defined as an area ID.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - areaId
+          properties:
+            areaId:
+              type: string
+              format: uuid              
 
     AreaName:
       description: The value of "AreaName" might be predefined and only regional or even an operator-specific in this API version. As a prerequisite, the API Provider may offer API Consumer the "AreaName" values, which API consumer can request, in a preparation phase. And then API Consumers can select from the "AreaNames" as Service Areas.


### PR DESCRIPTION
#### What type of PR is this?
* enhancement

#### What this PR does / why we need it:
To update CreateBooking so that API invoker can specify an area by either `id` or `name` based on the invoker's preference. This is a proposal to align with dedicated-network-areas API which is expected to be a common area API. 

#### Which issue(s) this PR fixes:
Fixes #86 

#### Special notes for reviewers:
This PR will merge only after consolidating and defining our common Area API. 

#### Changelog input
```
Add AreaID as requesting parameter
```

#### Additional documentation 
None