### PR TITLE
Plan update for alpha release r2.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -10,17 +10,17 @@ repository:
   # Options: independent (default) | meta-release
   release_track: meta-release
   # Meta-release participation (update for next cycle when planning)
-  meta_release: Fall25
+  meta_release: Sync26
 
   # Target CAMARA release tag.
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.2
+  target_release_tag: r2.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,14 +33,14 @@ dependencies:
 # - target_api_status: draft (no file yet) | alpha | rc | public
 apis:
   - api_name: qos-booking-and-assignment
-    target_api_version: 0.1.0
-    target_api_status: public
+    target_api_version: 0.2.0
+    target_api_status: alpha
     main_contacts:
       - Masa8106
       - jlurien
   - api_name: qos-booking
-    target_api_version: 0.1.0
-    target_api_status: public
+    target_api_version: 0.2.0
+    target_api_status: alpha
     main_contacts:
       - Masa8106
       - jlurien

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,9 +25,8 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-commonalities_release: r4.2
-identity_consent_management_release: r4.2
+  commonalities_release: r4.2
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -26,7 +26,8 @@ repository:
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
   commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+commonalities_release: r4.2
+identity_consent_management_release: r4.2
 
 # APIs in this repository
 # - api_name: kebab-case identifier (must be filename in code/API_definitions/)

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?
* repository management

#### What this PR does / why we need it:
This pull request proposes updated release plan for Sync26, changed target release tag to r2.1, and set release type to pre-release-alpha. Modified API versions and statuses for qos-booking-and-assignment and qos-booking.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for reviewers:
This is a prerequisite for starting the automated generation of the alpha release.
This is some kind of practice to get used to the new release process, even though there is some issues to be implemented later for Sync26.

#### Changelog input
```
Plan update for alpha release r2.1
```
#### Additional documentation 
None
