### PR TITLE
Plan update for rc release r2.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,13 +34,13 @@ dependencies:
 apis:
   - api_name: qos-booking-and-assignment
     target_api_version: 0.2.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - Masa8106
       - jlurien
   - api_name: qos-booking
     target_api_version: 0.2.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - Masa8106
       - jlurien


### PR DESCRIPTION
#### What type of PR is this?
* repository management

#### What this PR does / why we need it:
This pull request proposes updated release plan for Sync26, changed target release tag to r2.1, and set release type to pre-release-rc.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for reviewers:
None

#### Changelog input
```
Plan update for rc release r2.1
```
#### Additional documentation 
None