### PR TITLE
Add a new error code QOS_BOOKING.QOS_PROFILE_NOT_APPLICABLE

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -182,8 +182,8 @@ paths:
           $ref: "#/components/responses/GenericDevice404"
         "409":
           $ref: "#/components/responses/BookingConflict409"
-        "":
-          $ref: "#/components/responses/BookingUnprocessableEntity"
+        "422":
+          $ref: "#/components/responses/BookingUnprocessableEntity422"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -334,8 +334,8 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/GenericDevice404"
-        "":
-          $ref: "#/components/responses/Generic"
+        "422":
+          $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -1255,7 +1255,7 @@ components:
                 code: GONE
                 message: Access to the target resource is no longer available.
 
-    Generic:
+    Generic422:
       description: Unprocessable Content
       headers:
         x-correlator:

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -48,6 +48,8 @@ info:
 
     - If the subject can be identified from the access token and the optional `device` object is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same device is identified by these two methods, as the server is unable to make this comparison.
 
+    - If the requested `qosProfile` exists but is currently not available for creating a booking, then the server will return an error with the `422 QOS_BOOKING.QOS_PROFILE_NOT_APPLICABLE` error code.
+
     ### Additional CAMARA error responses
     The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
@@ -180,8 +182,8 @@ paths:
           $ref: "#/components/responses/GenericDevice404"
         "409":
           $ref: "#/components/responses/BookingConflict409"
-        "422":
-          $ref: "#/components/responses/BookingUnprocessableEntity422"
+        "":
+          $ref: "#/components/responses/BookingUnprocessableEntity"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -332,8 +334,8 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/GenericDevice404"
-        "422":
-          $ref: "#/components/responses/Generic422"
+        "":
+          $ref: "#/components/responses/Generic"
         "429":
           $ref: "#/components/responses/Generic429"
       security:
@@ -1253,7 +1255,7 @@ components:
                 code: GONE
                 message: Access to the target resource is no longer available.
 
-    Generic422:
+    Generic:
       description: Unprocessable Content
       headers:
         x-correlator:
@@ -1324,6 +1326,7 @@ components:
                       - QOS_BOOKING.NOT_MANAGED_AREA_TYPE
                       - QOS_BOOKING.AREA_NOT_COVERED
                       - QOS_BOOKING.INVALID_AREA
+                      - QOS_BOOKING.QOS_PROFILE_NOT_APPLICABLE
           examples:
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
@@ -1370,6 +1373,12 @@ components:
                 status: 422
                 code: QOS_BOOKING.INVALID_AREA
                 message: "The requested area is too small"
+            QOS_BOOKING_422_QOS_PROFILE_NOT_APPLICABLE:
+              description: The requested QoS Profile exists but cannot be used to create a booking.
+              value:
+                status: 422
+                code: QOS_BOOKING.QOS_PROFILE_NOT_APPLICABLE
+                message: The requested QoS Profile is currently not available for booking creation.
 
     Generic429:
       description: Too Many Requests


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Missing "QOS_PROFILE_NOT_APPLICABLE" error code which defined in quality-on-demand and qos-provisioning API.

#### Which issue(s) this PR fixes:
Fixes #103 

#### Special notes for reviewers:
This PR is based on [this comment](https://github.com/camaraproject/QoSBooking/pull/70/changes/BASE..25ebb98e5dece0b610439348ef2b75bc34254d04#r3441781635)

#### Changelog input
```
 release-note
 - Add a new error code QOS_BOOKING.QOS_PROFILE_NOT_APPLICABLE
```

#### Additional documentation 
None