### PR TITLE
Fixing Warnings due to info.description BEGIN/END Markers

### DIFF
--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -34,6 +34,7 @@ info:
      - An operation to get all the devices assigned to a given booking identified by its `BookingId`.
      - An operation to get all the associated QoS Booking for a given device.
 
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -41,6 +42,7 @@ info:
     The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
     # Identifying the device from the access token
 
@@ -65,6 +67,7 @@ info:
     - Identifying the intended device from a unique identifier for that device, such as its source IP address and port
     - Check with the SIM provider whether a unique "secondary" phone number is already associated with each device, and use the secondary phone number to identify the intended device if available
 
+    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
@@ -72,10 +75,13 @@ info:
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
 
+    <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
+    <!-- CAMARA:MANDATORY:request-body-strictness:END -->
 
     # Further info and support
     (FAQs will be added in a later version of the documentation)


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug
* tests


#### What this PR does / why we need it:

Validation checks produce warnings due to missing info.description templates.  


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:

Validation run: https://github.com/camaraproject/QoSBooking/actions/runs/28591196212 shows 3 warnings for QoS Booking and Assignment due to missing BEGIN/END markers

#### Changelog input

```
 release-note
- Added BEGIN/END markers as per common/info-description-templates.yaml

```

#### Additional documentation 

This section can be blank.



```
docs

```
