### PR TITLE
Rename AreaType

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -626,7 +626,7 @@ components:
       type: object
       properties:
         areaType:
-          $ref: "#/components/schemas/AreaType"
+          $ref: "#/components/schemas/QosBookingAreaType"
       required:
         - areaType
       discriminator:
@@ -636,7 +636,7 @@ components:
           POLYGON: "#/components/schemas/Polygon"
           AREANAME: "#/components/schemas/AreaName"
 
-    AreaType:
+    QosBookingAreaType:
       type: string
       description: |
         Type of this area.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Avoiding AreaType definition clash with common AreaType

#### Which issue(s) this PR fixes:
Fixes #110 

#### Special notes for reviewers:
None

#### Changelog input
```
 - Rename AreaType schema
```

#### Additional documentation 
None