### PR TITLE
QoS B: Update local error 409

### DIFF
--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -196,7 +196,7 @@ paths:
         "404":
           $ref: "#/components/responses/Generic404"
         "409":
-          $ref: "#/components/responses/BookingConflict409"
+          $ref: "#/components/responses/BookingAlreadyExists409"
         "422":
           $ref: "#/components/responses/BookingUnprocessableEntity422"
         "429":
@@ -864,8 +864,8 @@ components:
                 code: NOT_FOUND
                 message: The specified resource is not found.
 
-    BookingConflict409:
-      description: Conflict
+    BookingAlreadyExists409:
+      description: Trying to create a booking which already exists for this device
       headers:
         x-correlator:
           $ref: '#/components/headers/x-correlator'
@@ -881,11 +881,11 @@ components:
                       - 409
                   code:
                     enum:
-                      - CONFLICT
+                      - ALREADY_EXISTS
           example:
             status: 409
-            code: CONFLICT
-            message: Conflict with an existing booking for the same device.
+            code: ALREADY_EXISTS
+            message: The booking that a client tried to create already exists for this device.
 
     Generic410:
       $ref: '../common/CAMARA_common.yaml#/components/responses/Generic410'


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Error code "CONFLICT" has been deprecated by Commonalities. So it is needed to update from "CONFLICT" to "ALREADY_EXITSTS".

#### Which issue(s) this PR fixes:
Fixes #111 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
  - Update a code of local error 409 from "CONFLICT" to "ALREADY_EXITSTS". 
```

#### Additional documentation 
None