### PR TITLE
Update duration maximum

### DIFF
--- a/code/API_definitions/qos-booking-and-assignment.yaml
+++ b/code/API_definitions/qos-booking-and-assignment.yaml
@@ -1021,7 +1021,7 @@ components:
       type: integer
       format: int32
       minimum: 1
-      maximum: 86400
+      maximum: 2147483647
       example: 3600
 
     Devices:

--- a/code/API_definitions/qos-booking.yaml
+++ b/code/API_definitions/qos-booking.yaml
@@ -481,8 +481,7 @@ components:
               type: integer
               format: int32
               minimum: 1
-              maximum: 31622400
-              # Assume 1 year
+              maximum: 2147483647
             serviceArea:
               $ref: "#/components/schemas/Area"
           required:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
There is divergence on duration maximum among CQM APIs.
This PR proposes to set the `int32` ceiling as the value of duration maximum in QoS B and B&A APIs.
This is the same approach with quality-on-demand API.



#### Which issue(s) this PR fixes:
Fixes #113 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
  -Update duration maximum
```

#### Additional documentation 
None